### PR TITLE
Implement AuthenticateUserTicket

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -65,12 +65,14 @@ error!(SteamRemoteStorageError{
     GetPublishedFile(String)
 });
 
+error!(SteamUserAuthError{
+    AuthenticateUserTicket(String)
+});
 
 macro_rules! ErrorHandle {
     ($function:expr, $error:expr) => {
-        $function.map_err(move |error| { $error(error.to_string()) })?
+        $function.map_err(move |error| $error(error.to_string()))?
     };
 }
 
 pub(crate) use ErrorHandle;
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod steam_id;
 pub mod steam_news;
 pub mod steam_remote_storage;
 pub mod steam_user;
+pub mod steam_user_auth;
 pub mod steam_user_stats;
 pub mod steam_webapi_util;
 

--- a/src/steam_user/get_player_bans.rs
+++ b/src/steam_user/get_player_bans.rs
@@ -5,7 +5,7 @@ use serde_json::{from_value, Value};
 
 use crate::{
     Steam,
-    steam_id::{de_steamid_from_str, SteamId},
+    steam_id::SteamId,
     macros::do_http,
     errors::{ErrorHandle, SteamUserError},
     BASE

--- a/src/steam_user_auth/authenticate_user_ticket.rs
+++ b/src/steam_user_auth/authenticate_user_ticket.rs
@@ -1,0 +1,58 @@
+//! # Implements the `AuthenticateUserTicket` endpoint
+
+use std::fmt::Debug;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    errors::{ErrorHandle, SteamUserAuthError},
+    macros::{do_http, gen_args},
+    Steam, BASE,
+};
+
+use super::INTERFACE;
+
+const ENDPOINT: &str = "AuthenticateUserTicket";
+const VERSION: &str = "1";
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct TicketAuthResponse {
+    result: String,
+    #[serde(rename = "steamid")]
+    steam_id: String,
+    #[serde(rename = "ownersteamid")]
+    owner_steam_id: String,
+    #[serde(rename = "vacbanned")]
+    vac_banned: bool,
+    #[serde(rename = "publisherbanned")]
+    publisher_banned: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct WrapperParams {
+    params: TicketAuthResponse,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct Wrapper {
+    response: WrapperParams,
+}
+
+impl Steam {
+    pub async fn authenticate_user_ticket(
+        &self,
+        app_id: u32,
+        ticket: &str,
+    ) -> Result<TicketAuthResponse, SteamUserAuthError> {
+        let key = &self.api_key.clone();
+        let args = gen_args!(key, app_id, ticket);
+        let url = format!("{BASE}/{INTERFACE}/{ENDPOINT}/v{VERSION}/?{args}");
+        let wrapper = do_http!(
+            url,
+            Wrapper,
+            ErrorHandle,
+            SteamUserAuthError::AuthenticateUserTicket
+        );
+        Ok(wrapper.response.params)
+    }
+}

--- a/src/steam_user_auth/authenticate_user_ticket.rs
+++ b/src/steam_user_auth/authenticate_user_ticket.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     errors::{ErrorHandle, SteamUserAuthError},
-    macros::{do_http, gen_args},
+    macros::do_http,
     Steam, BASE,
 };
 
@@ -45,8 +45,7 @@ impl Steam {
         ticket: &str,
     ) -> Result<TicketAuthResponse, SteamUserAuthError> {
         let key = &self.api_key.clone();
-        let args = gen_args!(key, app_id, ticket);
-        let url = format!("{BASE}/{INTERFACE}/{ENDPOINT}/v{VERSION}/?{args}");
+        let url = format!("{BASE}/{INTERFACE}/{ENDPOINT}/v{VERSION}/?key={key}&appid={app_id}&ticket={ticket}");
         let wrapper = do_http!(
             url,
             Wrapper,

--- a/src/steam_user_auth/mod.rs
+++ b/src/steam_user_auth/mod.rs
@@ -1,0 +1,3 @@
+const INTERFACE: &str = "ISteamUserAuth";
+
+pub mod authenticate_user_ticket;

--- a/src/steam_user_auth/mod.rs
+++ b/src/steam_user_auth/mod.rs
@@ -1,3 +1,12 @@
+//! # Implements the `ISteamUserAuth` interface
+//!
+//! Used to authenticate users in your application.
+//! 
+//! **Note:** This implementation is incomplete!
+//! The following endpoints are currently unimplemented:
+//!
+//! - AuthenticateUser
+
 const INTERFACE: &str = "ISteamUserAuth";
 
 pub mod authenticate_user_ticket;

--- a/tests/steam_user_auth.rs
+++ b/tests/steam_user_auth.rs
@@ -1,0 +1,19 @@
+use steam_rs::Steam;
+
+mod common;
+
+#[test]
+pub fn authenticate_user_ticket() {
+    async_test!(async {
+        let steam = Steam::new(&std::env::var("STEAM_API_KEY").expect("Missing an API key"));
+        //12900 = Audiosurf
+        let query = steam
+            .authenticate_user_ticket(
+                12900,
+                &std::env::var("STEAM_GAME_TICKET").expect("Ticket should be provided"),
+            )
+            .await
+            .unwrap();
+        println!("{:?}", query);
+    });
+}


### PR DESCRIPTION
I started implementing ``ISteamUserAuth/AuthenticateUserTicket``. Haven't had a chance to test it, though.

There's also no *proper* error handling.
An example response for when the ticket is invalid looks like this:
```json
{
  "response": {
    "error": {
      "errorcode": 101,
      "errordesc": "Invalid ticket"
    }
  }
}
```