### PR TITLE
Make fields of TicketAuthResponse public

### DIFF
--- a/src/steam_user_auth/authenticate_user_ticket.rs
+++ b/src/steam_user_auth/authenticate_user_ticket.rs
@@ -17,15 +17,15 @@ const VERSION: &str = "1";
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct TicketAuthResponse {
-    result: String,
+    pub result: String,
     #[serde(rename = "steamid")]
-    steam_id: String,
+    pub steam_id: String,
     #[serde(rename = "ownersteamid")]
-    owner_steam_id: String,
+    pub owner_steam_id: String,
     #[serde(rename = "vacbanned")]
-    vac_banned: bool,
+    pub vac_banned: bool,
     #[serde(rename = "publisherbanned")]
-    publisher_banned: bool,
+    pub publisher_banned: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize)]


### PR DESCRIPTION
This fixes a *very obvious* oversight of mine: none of the fields on the struct returned by ``authenticate_user_ticket()`` were actually accessible.