### PR TITLE
Account type, universe and SteamID2 representation for SteamId

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,6 +513,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683751d591e6d81200c39fb0d1032608b77724f34114db54f571ff1317b337c0"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c11e44798ad209ccdd91fc192f0526a369a01234f7373e1b141c96d7cee4f0e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "object"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +638,15 @@ name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "proc-macro-crate"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
+dependencies = [
+ "toml_edit",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -857,6 +887,7 @@ dependencies = [
 name = "steam-rs"
 version = "0.3.1"
 dependencies = [
+ "num_enum",
  "rayon",
  "reqwest",
  "serde",
@@ -1001,6 +1032,23 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+
+[[package]]
+name = "toml_edit"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -1250,6 +1298,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "winnow"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["api-bindings"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+num_enum = "0.7.1"
 rayon = "1.7.0"
 reqwest = { version = "0.11.18", features = ["json"] }
 serde = { version = "1.0.175", features = ["derive"] }

--- a/src/steam_id.rs
+++ b/src/steam_id.rs
@@ -72,10 +72,12 @@ impl SteamId {
         (self.0 & 0xFFFFFFFF) as u32
     }
 
+    /// Get Universe that the `SteamId` belongs to.
     pub fn get_universe(self) -> Universe {
         Universe::try_from((self.0 >> 56) & 0xF).unwrap_or(Universe::Invalid)
     }
 
+    /// Get account type of the `SteamId`.
     pub fn get_account_type(&self) -> AccountType {
         AccountType::try_from((self.0 >> 52) & 0xF).unwrap_or(AccountType::Invalid)
     }
@@ -133,6 +135,7 @@ impl std::fmt::Display for ParseSteamIdError {
 
 impl std::error::Error for ParseSteamIdError {}
 
+/// Denotes what kind of account the SteamID belongs to.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, TryFromPrimitive)]
 #[repr(u64)]
 pub enum AccountType {

--- a/src/steam_id.rs
+++ b/src/steam_id.rs
@@ -63,17 +63,17 @@ impl SteamId {
     }
 
     /// Converts the `SteamId` into its underlying 64-bit unsigned integer value.
-    pub fn into_u64(self) -> u64 {
+    pub fn into_u64(&self) -> u64 {
         self.0
     }
 
-    /// Converts the `SteamId` into the unsigned 32-bit number used in its SteamID3.
-    pub fn into_u32(self) -> u32 {
+    /// Converts the `SteamId` into the unsigned 32-bit account ID used in its SteamID3 (and to some extent in the SteamID2).
+    pub fn get_account_id(&self) -> u32 {
         (self.0 & 0xFFFFFFFF) as u32
     }
 
     /// Get Universe that the `SteamId` belongs to.
-    pub fn get_universe(self) -> Universe {
+    pub fn get_universe(&self) -> Universe {
         Universe::try_from((self.0 >> 56) & 0xF).unwrap_or(Universe::Invalid)
     }
 
@@ -82,6 +82,16 @@ impl SteamId {
         AccountType::try_from((self.0 >> 52) & 0xF).unwrap_or(AccountType::Invalid)
     }
 
+    /// Get the `SteamId`'s SteamID2 string representation.
+    pub fn to_id2_string(&self) -> String {
+        let id = self.get_account_id();
+        format!(
+            "STEAM_{}:{}:{}",
+            self.get_universe() as u64,
+            id & 1,
+            id >> 1
+        )
+    }
 }
 
 impl FromStr for SteamId {

--- a/src/steam_id.rs
+++ b/src/steam_id.rs
@@ -1,6 +1,7 @@
 use core::fmt;
 use std::str::FromStr;
 
+use num_enum::TryFromPrimitive;
 use serde::{Deserialize, Serialize};
 
 /// Represents a SteamID64 type which is used to uniquely identify users on the Steam platform.
@@ -70,6 +71,15 @@ impl SteamId {
     pub fn into_u32(self) -> u32 {
         (self.0 & 0xFFFFFFFF) as u32
     }
+
+    pub fn get_universe(self) -> Universe {
+        Universe::try_from((self.0 >> 56) & 0xF).unwrap_or(Universe::Invalid)
+    }
+
+    pub fn get_account_type(&self) -> AccountType {
+        AccountType::try_from((self.0 >> 52) & 0xF).unwrap_or(AccountType::Invalid)
+    }
+
 }
 
 impl FromStr for SteamId {
@@ -122,3 +132,37 @@ impl std::fmt::Display for ParseSteamIdError {
 }
 
 impl std::error::Error for ParseSteamIdError {}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug, TryFromPrimitive)]
+#[repr(u64)]
+pub enum AccountType {
+    /// Used for bots and accounts which do not belong to another class.
+    Invalid,
+    /// Single user account.
+    Individual,
+    /// Multiseat (e.g. cybercafe) account.
+    Multiseat,
+    /// Game server account.
+    GameServer,
+    /// Anonymous game server account.
+    AnonGameServer,
+    /// Sometimes used to temporarily refer to Individual accounts until their credentials are verified with Steam.
+    Pending,
+    ContentServer,
+    Clan,
+    Chat,
+    /// Fake SteamID for local PSN account on PS3 or Live account on 360, etc.
+    P2PSuperSeeder,
+    AnonUser,
+}
+
+/// An "Universe" is an instance of Steam an account can belong to. "Public" is probably the one you'll be interacting with.
+#[derive(Copy, Clone, PartialEq, Eq, Debug, TryFromPrimitive)]
+#[repr(u64)]
+pub enum Universe {
+    Invalid,
+    Public,
+    Beta,
+    Internal,
+    Dev,
+}

--- a/tests/steam_id.rs
+++ b/tests/steam_id.rs
@@ -27,9 +27,9 @@ pub fn into_u64() {
 }
 
 #[test]
-pub fn into_u32() {
+pub fn get_account_id() {
     async_test!(async {
-        println!("{:?}", SteamId::new(EXAMPLE_STEAM_ID64).into_u32());
+        println!("{:?}", SteamId::new(EXAMPLE_STEAM_ID64).get_account_id());
     });
 }
 
@@ -44,5 +44,12 @@ pub fn get_universe() {
 pub fn get_account_type() {
     async_test!(async {
         println!("{:?}", SteamId::new(EXAMPLE_STEAM_ID64).get_account_type());
+    });
+}
+
+#[test]
+pub fn to_id2_string() {
+    async_test!(async {
+        println!("{:?}", SteamId::new(EXAMPLE_STEAM_ID64).to_id2_string());
     });
 }

--- a/tests/steam_id.rs
+++ b/tests/steam_id.rs
@@ -32,3 +32,17 @@ pub fn into_u32() {
         println!("{:?}", SteamId::new(EXAMPLE_STEAM_ID64).into_u32());
     });
 }
+
+#[test]
+pub fn get_universe() {
+    async_test!(async {
+        println!("{:?}", SteamId::new(EXAMPLE_STEAM_ID64).get_universe());
+    });
+}
+
+#[test]
+pub fn get_account_type() {
+    async_test!(async {
+        println!("{:?}", SteamId::new(EXAMPLE_STEAM_ID64).get_account_type());
+    });
+}


### PR DESCRIPTION
This PR:
- renames ``into_u32`` into ``get_account_id`` which is more accurate
- uses ``&self`` instead of ``self`` in ``SteamId`` since we don't need to take ownership
- adds ``AccountType`` and ``Universe`` enums (along with functions to get these from a ``SteamId``)
- adds [num_enum](https://github.com/illicitonion/num_enum) as a dependency for an easy way to convert primitives to enum variants (used for ``AccountType`` and ``Universe``)
- adds the ``to_id2_string`` function to get the ``SteamId``'s SteamID2 representation as a string
- adds tests and documentation for the new stuff

A lot of this was made using [steamid-ng](https://github.com/Majora320/steamid-ng) and Valve's documentation as a reference.