### PR TITLE
Make error module public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub mod steam_user_auth;
 pub mod steam_user_stats;
 pub mod steam_webapi_util;
 
-mod errors; // This remains private - maybe
+pub mod errors;
 mod macros; // This remains private
 
 const BASE: &str = "https://api.steampowered.com";


### PR DESCRIPTION
This PR makes the error module public, which is beneficial when you want to create custom error types that includes errors from `steam-rs`, instead of writing all errors as `Box<dyn std::error::Error>`