### PR TITLE
Implement `std::error::Error` for all error types

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -116,6 +116,8 @@ macro_rules! error {
                 }
             }
         }
+
+        impl std::error::Error for $enum_name {}
     };
 }
 


### PR DESCRIPTION
This will implement `std::error::Error` for all error types