### PR TITLE
Add avatar_hash field to player summaries

### DIFF
--- a/src/steam_user/get_player_summaries.rs
+++ b/src/steam_user/get_player_summaries.rs
@@ -44,6 +44,10 @@ pub struct Player {
     #[serde(rename = "avatarfull")]
     pub avatar_full: String,
 
+    /// Hash of the user's avatar
+    #[serde(rename = "avatarhash")]
+    pub avatar_hash: String,
+
     /// The user's status
     /// - 0: Offline (Also set when the profile is Private)
     /// - 1: Online


### PR DESCRIPTION
For some reason it isn't shown in the [Steam web API documentation](https://developer.valvesoftware.com/wiki/Steam_Web_API#GetPlayerSummaries_.28v0002.29), but there is also an `avatarhash` field returned by `GetPlayerSummaries`.

Here is the documentation's example response to demonstrate:
```
[eden@garden ~]$ curl http://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=<my key was here>\&steamids=76561197960435530
{"response":{"players":[{"steamid":"76561197960435530","communityvisibilitystate":3,"profilestate":1,"personaname":"Robin","profileurl":"https://steamcommunity.com/id/robinwalker/","avatar":"https://avatars.steamstatic.com/81b5478529dce13bf24b55ac42c1af7058aaf7a9.jpg","avatarmedium":"https://avatars.steamstatic.com/81b5478529dce13bf24b55ac42c1af7058aaf7a9_medium.jpg","avatarfull":"https://avatars.steamstatic.com/81b5478529dce13bf24b55ac42c1af7058aaf7a9_full.jpg","avatarhash":"81b5478529dce13bf24b55ac42c1af7058aaf7a9","personastate":0,"realname":"Robin Walker","primaryclanid":"103582791429521412","timecreated":1063407589,"personastateflags":0,"loccountrycode":"US","locstatecode":"WA","loccityid":3961}]}}
```