### PR TITLE
potential fix for get_owned_games function

### DIFF
--- a/src/player_service/get_owned_games.rs
+++ b/src/player_service/get_owned_games.rs
@@ -28,13 +28,13 @@ pub struct OwnedGames {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Game {
     pub appid: u32,
-    pub name: String,
+    pub name: Option<String>,
     pub playtime_forever: u64,
-    pub img_icon_url: String,
+    pub img_icon_url: Option<String>,
     pub capsule_filename: Option<String>,
-    pub has_workshop: bool,
-    pub has_market: bool,
-    pub has_dlc: bool,
+    pub has_workshop: Option<bool>,
+    pub has_market: Option<bool>,
+    pub has_dlc: Option<bool>,
 }
 
 impl Steam {


### PR DESCRIPTION
Currently the function takes the parameter include_appinfo, this reduces the returned info to just the appids and the hours played, The struct they are parsed to by serde however does not support recieving just those two fields. Updating more of the fields to be Options means the function can take it's second argument as false 