### PR TITLE
Implement IGameServerService endpoints

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -17,6 +17,7 @@ error!(PlayerServiceError{
 error!(GameServersServiceError{
     GetAccountList(String),
     GetAccountPublicInfo(String),
+    QueryLoginToken(String),
 });
 
 error!(SiteLicenseServiceError{

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -14,6 +14,10 @@ error!(PlayerServiceError{
     GetSteamLevel(String)
 });
 
+error!(GameServersServiceError{
+    GetAccountList(String),
+});
+
 error!(SiteLicenseServiceError{
     GetCurrentClientConnections(String),
     GetTotalPlaytime(String)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,6 +16,7 @@ error!(PlayerServiceError{
 
 error!(GameServersServiceError{
     GetAccountList(String),
+    GetAccountPublicInfo(String),
 });
 
 error!(SiteLicenseServiceError{

--- a/src/game_servers_service/get_account_list.rs
+++ b/src/game_servers_service/get_account_list.rs
@@ -1,0 +1,59 @@
+//! Implements the 'GetAccountList' endpoint.
+//! TODO: ALL THE DOCUMENTATION
+
+use serde::{Deserialize, Serialize};
+use serde_json::{from_value, Value};
+
+use crate::{
+    errors::{ErrorHandle, GameServersServiceError},
+    macros::do_http,
+    steam_id::{de_steamid_from_str, SteamId},
+    Steam, BASE,
+};
+
+use super::INTERFACE;
+
+const ENDPOINT: &str = "GetAccountList";
+const VERSION: &str = "1";
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct Server {
+    #[serde(rename = "steamid")]
+    #[serde(deserialize_with = "de_steamid_from_str")]
+    pub steam_id: SteamId,
+    pub appid: u32,
+    pub login_token: String,
+    pub memo: String,
+    pub is_deleted: bool,
+    pub is_expired: bool,
+    pub rt_last_logon: u32,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct AccountsResponse {
+    pub servers: Vec<Server>,
+    pub is_banned: bool,
+    pub expires: u32,
+    #[serde(deserialize_with = "de_steamid_from_str")]
+    pub actor: SteamId,
+    last_action_time: u32,
+}
+
+impl Steam {
+    /// Get the List of server accounts and details on them
+    pub async fn get_account_list(&self) -> Result<AccountsResponse, GameServersServiceError> {
+        let query = format!("?key={}", &self.api_key);
+        let url = format!("{}/{}/{}/v{}/{}", BASE, INTERFACE, ENDPOINT, VERSION, query);
+        let json = do_http!(
+            url,
+            Value,
+            ErrorHandle,
+            GameServersServiceError::GetAccountList
+        );
+        let wrapper: AccountsResponse = ErrorHandle!(
+            from_value(json.to_owned()),
+            GameServersServiceError::GetAccountList
+        );
+        Ok(wrapper)
+    }
+}

--- a/src/game_servers_service/get_account_list.rs
+++ b/src/game_servers_service/get_account_list.rs
@@ -1,5 +1,4 @@
 //! Implements the 'GetAccountList' endpoint.
-//! TODO: ALL THE DOCUMENTATION
 
 use serde::{Deserialize, Serialize};
 use serde_json::{from_value, Value};
@@ -20,7 +19,7 @@ const VERSION: &str = "1";
 pub struct Server {
     #[serde(rename = "steamid")]
     #[serde(deserialize_with = "de_steamid_from_str")]
-    pub steam_id: SteamId,
+    pub server_steam_id: SteamId,
     pub appid: u32,
     pub login_token: String,
     pub memo: String,
@@ -36,7 +35,7 @@ pub struct AccountsResponse {
     pub expires: u32,
     #[serde(deserialize_with = "de_steamid_from_str")]
     pub actor: SteamId,
-    last_action_time: u32,
+    pub last_action_time: u32,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -45,7 +44,7 @@ struct Wrapper {
 }
 
 impl Steam {
-    /// Get the List of server accounts and details on them
+    /// Get the List of server accounts linked to the account the steam key is connected to
     pub async fn get_account_list(&self) -> Result<AccountsResponse, GameServersServiceError> {
         let query = format!("?key={}", &self.api_key);
         let url = format!("{}/{}/{}/v{}/{}", BASE, INTERFACE, ENDPOINT, VERSION, query);

--- a/src/game_servers_service/get_account_list.rs
+++ b/src/game_servers_service/get_account_list.rs
@@ -39,6 +39,11 @@ pub struct AccountsResponse {
     last_action_time: u32,
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+struct Wrapper {
+    response: AccountsResponse,
+}
+
 impl Steam {
     /// Get the List of server accounts and details on them
     pub async fn get_account_list(&self) -> Result<AccountsResponse, GameServersServiceError> {
@@ -50,10 +55,10 @@ impl Steam {
             ErrorHandle,
             GameServersServiceError::GetAccountList
         );
-        let wrapper: AccountsResponse = ErrorHandle!(
+        let wrapper: Wrapper = ErrorHandle!(
             from_value(json.to_owned()),
             GameServersServiceError::GetAccountList
         );
-        Ok(wrapper)
+        Ok(wrapper.response)
     }
 }

--- a/src/game_servers_service/get_account_public_info.rs
+++ b/src/game_servers_service/get_account_public_info.rs
@@ -1,0 +1,51 @@
+//! Implements the 'GetAccountPublicInfo' endpoint.
+//! TODO: ALL THE DOCUMENTATION
+
+use serde::{Deserialize, Serialize};
+use serde_json::{from_value, Value};
+
+use crate::{
+    errors::{ErrorHandle, GameServersServiceError},
+    macros::do_http,
+    steam_id::{de_steamid_from_str, SteamId},
+    Steam, BASE,
+};
+
+use super::INTERFACE;
+
+const ENDPOINT: &str = "GetAccountPublicInfo";
+const VERSION: &str = "1";
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Wrapper {
+    response: Option<PublicInfoResponse>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct PublicInfoResponse {
+    #[serde(rename = "steamid")]
+    #[serde(deserialize_with = "de_steamid_from_str")]
+    steam_id: SteamId,
+    appid: u32,
+}
+
+impl Steam {
+    pub async fn get_account_public_info(
+        &self,
+        steam_id: SteamId,
+    ) -> Result<Option<PublicInfoResponse>, GameServersServiceError> {
+        let query = format!("?key={}&steamid={}", &self.api_key, steam_id.0);
+        let url = format!("{}/{}/{}/v{}/{}", BASE, INTERFACE, ENDPOINT, VERSION, query);
+        let json = do_http!(
+            url,
+            Value,
+            ErrorHandle,
+            GameServersServiceError::GetAccountPublicInfo
+        );
+        let wrapper: Wrapper = ErrorHandle!(
+            from_value(json.to_owned()),
+            GameServersServiceError::GetAccountPublicInfo
+        );
+        Ok(wrapper.response)
+    }
+}

--- a/src/game_servers_service/get_account_public_info.rs
+++ b/src/game_servers_service/get_account_public_info.rs
@@ -1,5 +1,4 @@
 //! Implements the 'GetAccountPublicInfo' endpoint.
-//! TODO: ALL THE DOCUMENTATION
 
 use serde::{Deserialize, Serialize};
 use serde_json::{from_value, Value};
@@ -25,16 +24,20 @@ pub struct Wrapper {
 pub struct PublicInfoResponse {
     #[serde(rename = "steamid")]
     #[serde(default, deserialize_with = "de_steamid_from_str_opt")]
-    steam_id: Option<SteamId>,
+    server_steam_id: Option<SteamId>,
     appid: Option<u32>,
 }
 
 impl Steam {
+    // Get the public accessable info about a steam server from it's steam id.
+    //
+    // # Arguments
+    // * `server_steam_id` - The server's steam id, this can be got from such functions as 'get_account_list` user accounts wont return anything
     pub async fn get_account_public_info(
         &self,
-        steam_id: SteamId,
+        server_steam_id: SteamId,
     ) -> Result<PublicInfoResponse, GameServersServiceError> {
-        let query = format!("?key={}&steamid={}", &self.api_key, steam_id.0);
+        let query = format!("?key={}&steamid={}", &self.api_key, server_steam_id.0);
         let url = format!("{}/{}/{}/v{}/{}", BASE, INTERFACE, ENDPOINT, VERSION, query);
         let json = do_http!(
             url,

--- a/src/game_servers_service/get_account_public_info.rs
+++ b/src/game_servers_service/get_account_public_info.rs
@@ -7,7 +7,7 @@ use serde_json::{from_value, Value};
 use crate::{
     errors::{ErrorHandle, GameServersServiceError},
     macros::do_http,
-    steam_id::{de_steamid_from_str, SteamId},
+    steam_id::{de_steamid_from_str_opt, SteamId},
     Steam, BASE,
 };
 
@@ -18,15 +18,15 @@ const VERSION: &str = "1";
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Wrapper {
-    response: Option<PublicInfoResponse>,
+    response: PublicInfoResponse,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PublicInfoResponse {
     #[serde(rename = "steamid")]
-    #[serde(deserialize_with = "de_steamid_from_str")]
-    steam_id: SteamId,
-    appid: u32,
+    #[serde(deserialize_with = "de_steamid_from_str_opt")]
+    steam_id: Option<SteamId>,
+    appid: Option<u32>,
 }
 
 impl Steam {

--- a/src/game_servers_service/get_account_public_info.rs
+++ b/src/game_servers_service/get_account_public_info.rs
@@ -33,7 +33,7 @@ impl Steam {
     pub async fn get_account_public_info(
         &self,
         steam_id: SteamId,
-    ) -> Result<Option<PublicInfoResponse>, GameServersServiceError> {
+    ) -> Result<PublicInfoResponse, GameServersServiceError> {
         let query = format!("?key={}&steamid={}", &self.api_key, steam_id.0);
         let url = format!("{}/{}/{}/v{}/{}", BASE, INTERFACE, ENDPOINT, VERSION, query);
         let json = do_http!(

--- a/src/game_servers_service/get_account_public_info.rs
+++ b/src/game_servers_service/get_account_public_info.rs
@@ -24,7 +24,7 @@ pub struct Wrapper {
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PublicInfoResponse {
     #[serde(rename = "steamid")]
-    #[serde(deserialize_with = "de_steamid_from_str_opt")]
+    #[serde(default, deserialize_with = "de_steamid_from_str_opt")]
     steam_id: Option<SteamId>,
     appid: Option<u32>,
 }

--- a/src/game_servers_service/get_servers_steam_ids_by_ip.rs
+++ b/src/game_servers_service/get_servers_steam_ids_by_ip.rs
@@ -1,0 +1,11 @@
+//! Implements the 'GetServerSteamIDsByIP' endpoint.
+//!
+//! This endpoint is poorly explained in the steam docs.
+//! The server that is sent through the "server_ips" argument really refers to
+//! severs linked to the key (set up with `Steam::new(key)`) basically only linked
+//! servers can be polled, if you have these servers they should be also viewable
+//! through the function `get_account_list` as the `servers` field.
+
+// Currently I don't have access to something to run a steam server on so I can't test the returns of the endpoint
+// and since steam doesn't offer an example return it is a bit hard to develop this code, this should be fixable by
+// creating my own server which will be possible soon.

--- a/src/game_servers_service/mod.rs
+++ b/src/game_servers_service/mod.rs
@@ -1,6 +1,18 @@
 //! # Implements the IGameServersService interface
 //!
 //! Provides addtional methods for administration of Steam Game Servers
+//! It's worth noting that steam ids aren't just for user accounts, servers also have steam ids
+//! These aren't well differentiated within the docs for the steam api
+//!
+//! **Note:** This implementation is incomplete! The following endpoints are currently unimplemented
+//!
+//! - CreateAccount
+//! - SetMemo
+//! - ResetLoginToken
+//! - DeleteAccount
+//! - QueryLoginToken
+//! - GetServerSteamIDsByIP
+//! - GetServerIPsBySteamID
 
 const INTERFACE: &str = "IGameServersService";
 

--- a/src/game_servers_service/mod.rs
+++ b/src/game_servers_service/mod.rs
@@ -10,7 +10,6 @@
 //! - SetMemo
 //! - ResetLoginToken
 //! - DeleteAccount
-//! - QueryLoginToken
 //! - GetServerSteamIDsByIP
 //! - GetServerIPsBySteamID
 
@@ -18,3 +17,4 @@ const INTERFACE: &str = "IGameServersService";
 
 pub mod get_account_list;
 pub mod get_account_public_info;
+pub mod query_login_token;

--- a/src/game_servers_service/mod.rs
+++ b/src/game_servers_service/mod.rs
@@ -1,0 +1,7 @@
+//! # Implements the IGameServersService interface
+//!
+//! Provides addtional methods for administration of Steam Game Servers
+
+const INTERFACE: &str = "IGameServersService";
+
+pub mod get_account_list;

--- a/src/game_servers_service/mod.rs
+++ b/src/game_servers_service/mod.rs
@@ -5,3 +5,4 @@
 const INTERFACE: &str = "IGameServersService";
 
 pub mod get_account_list;
+pub mod get_account_public_info;

--- a/src/game_servers_service/query_login_token.rs
+++ b/src/game_servers_service/query_login_token.rs
@@ -1,0 +1,56 @@
+//! Implements the `QueryLoginToken` endpoint
+
+use crate::steam_id::de_steamid_from_str;
+use serde::{Deserialize, Serialize};
+use serde_json::{from_value, Value};
+
+use crate::{
+    errors::{ErrorHandle, GameServersServiceError},
+    macros::do_http,
+    steam_id::SteamId,
+    Steam, BASE,
+};
+
+use super::INTERFACE;
+
+const ENDPOINT: &str = "QueryLoginToken";
+const VERSION: &str = "1";
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct Wrapper {
+    response: LoginTokenResponse,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct LoginTokenResponse {
+    is_banned: bool,
+    expires: u32,
+    #[serde(rename = "steamid")]
+    #[serde(deserialize_with = "de_steamid_from_str")]
+    server_steam_id: SteamId,
+}
+
+impl Steam {
+    // Get the information on a login token for a server
+    //
+    // # Arguments
+    // * login_token : Token for a server, can be sourced from 'get_account_list'
+    pub async fn query_login_token(
+        &self,
+        login_token: &str,
+    ) -> Result<LoginTokenResponse, GameServersServiceError> {
+        let query = format!("?key={}&login_token={}", &self.api_key, login_token);
+        let url = format!("{}/{}/{}/v{}/{}", BASE, INTERFACE, ENDPOINT, VERSION, query);
+        let json = do_http!(
+            url,
+            Value,
+            ErrorHandle,
+            GameServersServiceError::QueryLoginToken
+        );
+        let wrapper: Wrapper = ErrorHandle!(
+            from_value(json.to_owned()),
+            GameServersServiceError::QueryLoginToken
+        );
+        Ok(wrapper.response)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 //! This crate is currently a work in progress, so please expect breaking changes and instability. Please be careful when using this! **This is not production ready!**
 
 pub mod econ_service;
+pub mod game_servers_service;
 pub mod player_service;
 pub mod published_file_service;
 pub mod site_license_service;


### PR DESCRIPTION
This is a pr to fix #4 
A lot of these services require linked servers to accounts I've written (following style guides of the rest of the end points) the ones I can with a linked server to my account key, when I get access to a device which can run a steam server on it I will be able to fill out the rest of the methods 

It's worth noting a lot of the methods under this group are POST, I haven't seen precedent for this within the library so far. So work might need to be done in that respect

I also had to expand `de_steamid_from_str` to have a second optional version to handle one of the endpoints having an optional SteamID field. 
