### PR TITLE
Implement serde manually for `SteamId`

### DIFF
--- a/src/game_servers_service/get_account_list.rs
+++ b/src/game_servers_service/get_account_list.rs
@@ -6,7 +6,7 @@ use serde_json::{from_value, Value};
 use crate::{
     errors::{ErrorHandle, GameServersServiceError},
     macros::do_http,
-    steam_id::{de_steamid_from_str, SteamId},
+    steam_id::SteamId,
     Steam, BASE,
 };
 
@@ -18,7 +18,6 @@ const VERSION: &str = "1";
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Server {
     #[serde(rename = "steamid")]
-    #[serde(deserialize_with = "de_steamid_from_str")]
     pub server_steam_id: SteamId,
     pub appid: u32,
     pub login_token: String,
@@ -33,7 +32,6 @@ pub struct AccountsResponse {
     pub servers: Vec<Server>,
     pub is_banned: bool,
     pub expires: u32,
-    #[serde(deserialize_with = "de_steamid_from_str")]
     pub actor: SteamId,
     pub last_action_time: u32,
 }

--- a/src/game_servers_service/get_account_public_info.rs
+++ b/src/game_servers_service/get_account_public_info.rs
@@ -6,7 +6,7 @@ use serde_json::{from_value, Value};
 use crate::{
     errors::{ErrorHandle, GameServersServiceError},
     macros::do_http,
-    steam_id::{de_steamid_from_str_opt, SteamId},
+    steam_id::SteamId,
     Steam, BASE,
 };
 
@@ -23,7 +23,6 @@ pub struct Wrapper {
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PublicInfoResponse {
     #[serde(rename = "steamid")]
-    #[serde(default, deserialize_with = "de_steamid_from_str_opt")]
     server_steam_id: Option<SteamId>,
     appid: Option<u32>,
 }

--- a/src/game_servers_service/query_login_token.rs
+++ b/src/game_servers_service/query_login_token.rs
@@ -1,6 +1,5 @@
 //! Implements the `QueryLoginToken` endpoint
 
-use crate::steam_id::de_steamid_from_str;
 use serde::{Deserialize, Serialize};
 use serde_json::{from_value, Value};
 
@@ -26,7 +25,6 @@ pub struct LoginTokenResponse {
     is_banned: bool,
     expires: u32,
     #[serde(rename = "steamid")]
-    #[serde(deserialize_with = "de_steamid_from_str")]
     server_steam_id: SteamId,
 }
 

--- a/src/published_file_service/query_files.rs
+++ b/src/published_file_service/query_files.rs
@@ -216,6 +216,19 @@ pub struct PlaytimeStats {
     pub num_sessions: String,
 }
 
+/// Represents a file a given [File] depends on.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ChildFile {
+    /// The child's published file ID.
+    #[serde(rename = "publishedfileid")]
+    pub published_file_id: String,
+    /// The sort order of the child file.
+    #[serde(rename = "sortorder")]
+    pub sort_order: u16,
+    /// The child's filetype
+    pub file_type: u8,
+}
+
 /// Represents file information retrieved from the Steam Workshop.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct File {
@@ -303,6 +316,9 @@ pub struct File {
     pub num_children: u32,
     /// The number of reports.
     pub num_reports: u32,
+    /// The IDs of child items
+    #[serde(default)]
+    pub children: Vec<ChildFile>,
     /// Previews associated with the file.
     #[serde(default)]
     pub previews: Vec<Preview>,

--- a/src/published_file_service/query_files.rs
+++ b/src/published_file_service/query_files.rs
@@ -304,8 +304,10 @@ pub struct File {
     /// The number of reports.
     pub num_reports: u32,
     /// Previews associated with the file.
+    #[serde(default)]
     pub previews: Vec<Preview>,
     /// Tags associated with the file.
+    #[serde(default)]
     pub tags: Vec<Tag>,
     /// Vote data associated with the file.
     pub vote_data: VoteData,
@@ -322,6 +324,7 @@ pub struct File {
     /// The revision number.
     pub revision: u32,
     /// Available revisions for the file.
+    #[serde(default)]
     pub available_revisions: Vec<u32>,
     /// Ban text check result.
     pub ban_text_check_result: u32,

--- a/src/published_file_service/query_files.rs
+++ b/src/published_file_service/query_files.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     errors::{ErrorHandle, PublishedFileServiceError},
     macros::{do_http, optional_argument},
-    steam_id::{de_steamid_from_str, SteamId},
+    steam_id::SteamId,
     Steam, BASE,
 };
 
@@ -225,7 +225,6 @@ pub struct File {
     #[serde(rename = "publishedfileid")]
     pub published_file_id: String,
     /// The Steam ID of the creator.
-    #[serde(deserialize_with = "de_steamid_from_str")]
     pub creator: SteamId,
     /// The ID of the application (game) that created the file.
     pub creator_appid: u32,

--- a/src/steam_user/get_friend_list.rs
+++ b/src/steam_user/get_friend_list.rs
@@ -8,7 +8,7 @@ use serde_json::{from_value, Value};
 use crate::{
     errors::{ErrorHandle, SteamUserError},
     macros::{do_http, optional_argument},
-    steam_id::{de_steamid_from_str, SteamId},
+    steam_id::SteamId,
     Steam, BASE,
 };
 
@@ -41,7 +41,6 @@ impl fmt::Display for Relationship {
 pub struct Friend {
     /// The 64 bit ID of the friend.
     #[serde(rename = "steamid")]
-    #[serde(deserialize_with = "de_steamid_from_str")]
     pub steam_id: SteamId,
 
     /// Role in relation to the given SteamID.

--- a/src/steam_user/get_player_summaries.rs
+++ b/src/steam_user/get_player_summaries.rs
@@ -6,7 +6,7 @@ use serde_json::{from_value, Value};
 use crate::{
     errors::{ErrorHandle, SteamUserError},
     macros::do_http,
-    steam_id::{de_steamid_from_str, SteamId},
+    steam_id::SteamId,
     Steam, BASE,
 };
 
@@ -22,7 +22,6 @@ const VERSION: &str = "0002";
 pub struct Player {
     /// The user's 64-bit ID
     #[serde(rename = "steamid")]
-    #[serde(deserialize_with = "de_steamid_from_str")]
     pub steam_id: SteamId,
 
     /// User's display name.


### PR DESCRIPTION
Implements `Deserialize` and `Serialize` traits for `SteamId` manually, which removes the need for functions like `de_steamid_from_str` and `de_steamid_from_str_opt`.

I have also set `SteamId` to serialize as a string instead of its current default behavior (to an integer), which allows deserializing any structs that were serialized containing a `SteamId` automatically (i.e. for caching queries on disk).

Also part of this PR is setting some vecs in `query_files` to serialize as empty as a fallback as the empty fields were causing the function to return an error. This might also be applicable to other endpoints that omit fields for empty lists, I have not checked extensively.