### PR TITLE
Add support for creating `SteamId` from any Steam ID version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +307,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "pomsky"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddec9a830740eacb682ea0690f27e4a1c0dcba391aa40dfc03e47fb0ddbf0578"
+dependencies = [
+ "pomsky-syntax",
+]
+
+[[package]]
+name = "pomsky-macro"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5041df9017eb4b3a5c32654076943684f848a238b6d9ee172b6c6e045f426cf"
+dependencies = [
+ "pomsky",
+]
+
+[[package]]
+name = "pomsky-syntax"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c3ed2ebe30f78d20b329173899c7758d55202ab3186fe5b43e02ce9a979cfb"
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,6 +385,35 @@ checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ring"
@@ -495,7 +557,10 @@ version = "0.5.1"
 dependencies = [
  "minreq",
  "num_enum",
+ "pomsky",
+ "pomsky-macro",
  "rayon",
+ "regex",
  "serde",
  "serde-this-or-that",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,10 @@ categories = ["api-bindings"]
 [dependencies]
 minreq = { version = "2.11.0", features = ["https", "json-using-serde"] }
 num_enum = "0.7.2"
+pomsky = "0.11.0"
+pomsky-macro = "0.11.0"
 rayon = "1.8.1"
+regex = "1.11.1"
 serde = { version = "1.0.196", features = ["derive"] }
 serde-this-or-that = "0.5.0"
 serde_json = "1.0.113"

--- a/src/steam_id.rs
+++ b/src/steam_id.rs
@@ -48,7 +48,7 @@ static STEAM3_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(STEAM3_REGEX_
 /// println!("SteamId: {}", steam_id);
 ///
 /// let smart_steam_id = SteamId::new_smart("STEAM_1:0:11101");
-/// println!("SteamId: {}", steam_id);
+/// println!("SteamId: {}", smart_steam_id);
 /// ```
 ///
 /// # Conversions

--- a/src/steam_id.rs
+++ b/src/steam_id.rs
@@ -1,7 +1,38 @@
 use core::fmt;
+use std::sync::LazyLock;
 
 use num_enum::TryFromPrimitive;
+use pomsky_macro::pomsky;
+use regex::{Match, Regex};
 use serde::{Deserialize, Deserializer, Serialize};
+
+const STEAM2_REGEX_STR: &str = pomsky! {
+    ^
+    "STEAM_"
+    :universe(['0'-'4'])
+    ":"
+    :authServer(['0'-'1'])
+    ":"
+    :id('0' | ['1'-'9']['0'-'9']{0,9})
+    $
+};
+
+static STEAM2_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(STEAM2_REGEX_STR).unwrap());
+
+const STEAM3_REGEX_STR: &str = pomsky! {
+    ^
+    "["
+    :type(["AGMPCgcLTIUai"])
+    ":"
+    :universe(['0'-'4'])
+    ":"
+    :id('0' | ['1'-'9']['0'-'9']{0,9})
+    (":":instance(['0'-'9']+))?
+    "]"
+    $
+};
+
+static STEAM3_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(STEAM3_REGEX_STR).unwrap());
 
 /// Represents a SteamID64 type which is used to uniquely identify users on the Steam platform.
 /// SteamID64 is a 64-bit unsigned integer.
@@ -14,6 +45,9 @@ use serde::{Deserialize, Deserializer, Serialize};
 /// use steam_rs::steam_id::SteamId;
 ///
 /// let steam_id = SteamId::new(76561197960287930);
+/// println!("SteamId: {}", steam_id);
+///
+/// let smart_steam_id = SteamId::new_smart("STEAM_1:0:11101");
 /// println!("SteamId: {}", steam_id);
 /// ```
 ///
@@ -57,10 +91,151 @@ impl fmt::Display for SteamId {
     }
 }
 
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SteamIdError {
+    Invalid,
+    TooBig(String, u64),
+}
+
+impl std::fmt::Display for SteamIdError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let msg = match self {
+            Self::Invalid => "Provided SteamID is invalid.",
+            Self::TooBig(what, limit) => &format!("{what} cannot be bigger than {limit}."),
+        };
+
+        write!(f, "{msg}")
+    }
+}
+
+impl std::error::Error for SteamIdError {}
+
 impl SteamId {
     /// Creates a new `SteamId` instance with the given 64-bit unsigned integer value.
     pub fn new(value: u64) -> Self {
         SteamId(value)
+    }
+
+    /// Creates a new `SteamId` instance from any Steam ID version.
+    pub fn new_smart(value: &str) -> Result<Self, SteamIdError> {
+        let mut steam_id = Self::new(0);
+
+        let match_to_u64 = |m: Match| m.as_str().parse::<u64>().unwrap();
+
+        if let Some(captures) = STEAM2_REGEX.captures(value) {
+            let account_id = captures.name("id").map(match_to_u64).unwrap();
+            if account_id > u32::MAX as u64 {
+                return Err(SteamIdError::TooBig("SteamID".to_owned(), u32::MAX as u64));
+            }
+
+            let mut universe = captures.name("universe").map(match_to_u64).unwrap();
+            if universe == Universe::Invalid as u64 {
+                universe = Universe::Public as u64;
+            }
+
+            let auth_server = captures.name("authServer").map(match_to_u64).unwrap();
+            let account_id = (account_id << 1) | auth_server;
+
+            steam_id.set_account_universe(universe)?;
+            steam_id.set_account_instance(AccountInstance::Desktop as u64)?;
+            steam_id.set_account_type(AccountType::Individual as u64)?;
+            steam_id.set_account_id(account_id)?;
+
+            return Ok(steam_id);
+        }
+
+        if let Some(captures) = STEAM3_REGEX.captures(value) {
+            let account_id = captures.name("id").map(match_to_u64).unwrap();
+            if account_id > u32::MAX as u64 {
+                return Err(SteamIdError::TooBig("SteamID".to_owned(), u32::MAX as u64));
+            }
+
+            let letter_str = captures.name("type").unwrap().as_str();
+            let letter = letter_str.chars().next().unwrap();
+            let mut instance = match (letter, captures.name("instance")) {
+                ('U', None) => AccountInstance::Desktop,
+                (_, Some(m)) => {
+                    AccountInstance::try_from(match_to_u64(m)).unwrap_or(AccountInstance::All)
+                }
+                _ => AccountInstance::All,
+            };
+
+            match letter {
+                'c' => {
+                    instance = AccountInstance::FlagClan;
+                    steam_id.set_account_type(AccountType::Chat as u64)?;
+                }
+                'L' => {
+                    instance = AccountInstance::FlagLobby;
+                    steam_id.set_account_type(AccountType::Chat as u64)?;
+                }
+                _ => steam_id.set_account_type(AccountType::from(letter) as u64)?,
+            }
+
+            let universe = captures.name("universe").map(match_to_u64).unwrap();
+
+            steam_id.set_account_universe(universe)?;
+            steam_id.set_account_instance(instance as u64)?;
+            steam_id.set_account_id(account_id)?;
+            return Ok(steam_id);
+        }
+
+        value
+            .parse()
+            .map(Self::new)
+            .map_err(|_| SteamIdError::Invalid)
+    }
+
+    /// Set account universe directly.
+    pub fn set_account_universe(&mut self, value: u64) -> Result<(), SteamIdError> {
+        if value > 0xFF {
+            return Err(SteamIdError::TooBig("Account universe".to_owned(), 0xFF));
+        }
+
+        self.set(56, 0xFF, value);
+
+        Ok(())
+    }
+
+    /// Set account instance directly.
+    pub fn set_account_instance(&mut self, value: u64) -> Result<(), SteamIdError> {
+        if value > 0xFFFFF {
+            return Err(SteamIdError::TooBig("Account instance".to_owned(), 0xFFFFF));
+        }
+
+        self.set(32, 0xFFFFF, value);
+
+        Ok(())
+    }
+
+    /// Set account type directly.
+    pub fn set_account_type(&mut self, value: u64) -> Result<(), SteamIdError> {
+        if value > 0xF {
+            return Err(SteamIdError::TooBig("Account type".to_owned(), 0xF));
+        }
+
+        self.set(52, 0xF, value);
+
+        Ok(())
+    }
+
+    /// Set account ID directly.
+    pub fn set_account_id(&mut self, value: u64) -> Result<(), SteamIdError> {
+        if value > 0xFFFFFFFF {
+            return Err(SteamIdError::TooBig("Account ID".to_owned(), 0xFFFFFFFF));
+        }
+
+        self.set(0, 0xFFFFFFFF, value);
+
+        Ok(())
+    }
+
+    fn set(&mut self, offset: u8, mask: u64, value: u64) {
+        self.0 = (self.0 & !(mask << offset)) | ((value & mask) << offset);
+    }
+
+    fn get(&self, offset: u8, mask: u64) -> u64 {
+        (self.0 >> offset) & mask
     }
 
     /// Converts the `SteamId` into its underlying 64-bit unsigned integer value.
@@ -70,17 +245,24 @@ impl SteamId {
 
     /// Converts the `SteamId` into the unsigned 32-bit account ID used in its SteamID3 (and to some extent in the SteamID2).
     pub fn get_account_id(&self) -> u32 {
-        (self.0 & 0xFFFFFFFF) as u32
+        self.get(0, 0xFFFFFFFF) as u32
+    }
+
+    /// Get account instance of the `SteamId`.
+    ///
+    /// Note: To get [AccountInstance] value use `AccountInstance::try_from(u32)`
+    pub fn get_account_instance(&self) -> u32 {
+        self.get(32, 0xFFFFF) as u32
     }
 
     /// Get Universe that the `SteamId` belongs to.
     pub fn get_universe(&self) -> Universe {
-        Universe::try_from((self.0 >> 56) & 0xF).unwrap_or(Universe::Invalid)
+        Universe::try_from(self.get(56, 0xFF)).unwrap_or(Universe::Invalid)
     }
 
     /// Get account type of the `SteamId`.
     pub fn get_account_type(&self) -> AccountType {
-        AccountType::try_from((self.0 >> 52) & 0xF).unwrap_or(AccountType::Invalid)
+        AccountType::try_from(self.get(52, 0xF)).unwrap_or(AccountType::Invalid)
     }
 
     /// Get the `SteamId`'s SteamID2 string representation.
@@ -92,6 +274,37 @@ impl SteamId {
             id & 1,
             id >> 1
         )
+    }
+
+    pub fn to_id3_string(&self) -> String {
+        let account_instance = self.get_account_instance();
+        let account_type = self.get_account_type();
+        let mut account_type_char: char = account_type.into();
+
+        let mut render_instance = false;
+
+        match account_type {
+            AccountType::Chat if (account_instance & AccountInstance::FlagClan as u32) != 0 => {
+                account_type_char = 'c'
+            }
+            AccountType::Chat if (account_instance & AccountInstance::FlagLobby as u32) != 0 => {
+                account_type_char = 'L'
+            }
+            AccountType::AnonGameServer | AccountType::Multiseat => render_instance = true,
+            _ => {}
+        };
+
+        let universe = self.get_universe() as u32;
+        let account_id = self.get_account_id();
+        let mut string = format!("[{account_type_char}:{universe}:{account_id}");
+
+        if render_instance {
+            string += &format!(":{account_instance}");
+        }
+
+        string += "]";
+
+        string
     }
 }
 
@@ -149,6 +362,19 @@ impl std::fmt::Display for ParseSteamIdError {
 
 impl std::error::Error for ParseSteamIdError {}
 
+#[derive(Copy, Clone, PartialEq, Eq, Debug, TryFromPrimitive)]
+#[repr(u64)]
+pub enum AccountInstance {
+    All,
+    Desktop,
+    Console,
+    Web,
+
+    FlagMMSLobby = 131072,
+    FlagLobby = 262144,
+    FlagClan = 524288,
+}
+
 /// Denotes what kind of account the SteamID belongs to.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, TryFromPrimitive)]
 #[repr(u64)]
@@ -171,6 +397,42 @@ pub enum AccountType {
     /// Fake SteamID for local PSN account on PS3 or Live account on 360, etc.
     P2PSuperSeeder,
     AnonUser,
+}
+
+impl From<char> for AccountType {
+    fn from(value: char) -> Self {
+        match value {
+            'I' | 'i' => Self::Invalid,
+            'U' => Self::Individual,
+            'M' => Self::Multiseat,
+            'G' => Self::GameServer,
+            'A' => Self::AnonGameServer,
+            'P' => Self::Pending,
+            'C' => Self::ContentServer,
+            'g' => Self::Clan,
+            'T' | 'L' | 'c' => Self::Chat,
+            'a' => Self::AnonUser,
+            _ => Self::Invalid,
+        }
+    }
+}
+
+impl From<AccountType> for char {
+    fn from(account_type: AccountType) -> char {
+        match account_type {
+            AccountType::Invalid => 'I',
+            AccountType::Individual => 'U',
+            AccountType::Multiseat => 'M',
+            AccountType::GameServer => 'G',
+            AccountType::AnonGameServer => 'A',
+            AccountType::Pending => 'P',
+            AccountType::ContentServer => 'C',
+            AccountType::Clan => 'g',
+            AccountType::Chat => 'T', // Lobby chat is 'L', Clan chat is 'c'
+            AccountType::P2PSuperSeeder => ' ',
+            AccountType::AnonUser => 'a',
+        }
+    }
 }
 
 /// An "Universe" is an instance of Steam an account can belong to. "Public" is probably the one you'll be interacting with.

--- a/src/steam_id.rs
+++ b/src/steam_id.rs
@@ -186,6 +186,17 @@ impl SteamId {
             .map_err(|_| SteamIdError::Invalid)
     }
 
+    /// Creates a new [AccountType::Individual] `SteamId` in public universe from a given account id.
+    pub fn from_account_id(account_id: u32) -> Result<Self, SteamIdError> {
+        let mut steam_id = SteamId::new(0);
+        steam_id.set_account_id(account_id as u64)?;
+        steam_id.set_account_instance(AccountInstance::Desktop as u64)?;
+        steam_id.set_account_type(AccountType::Individual as u64)?;
+        steam_id.set_account_universe(Universe::Public as u64)?;
+
+        Ok(steam_id)
+    }
+
     /// Set account universe directly.
     pub fn set_account_universe(&mut self, value: u64) -> Result<(), SteamIdError> {
         if value > 0xFF {

--- a/tests/steam_id.rs
+++ b/tests/steam_id.rs
@@ -1,4 +1,4 @@
-use steam_rs::steam_id::SteamId;
+use steam_rs::steam_id::{SteamId, Universe};
 
 mod common;
 
@@ -32,4 +32,20 @@ pub async fn get_account_type() {
 #[tokio::test]
 pub async fn to_id2_string() {
     println!("{:?}", SteamId::new(EXAMPLE_STEAM_ID64).to_id2_string());
+}
+
+#[tokio::test]
+async fn new_smart() {
+    let sid = SteamId::new_smart("STEAM_1:1:161214314");
+    assert!(sid.is_ok());
+
+    let mut sid = sid.unwrap();
+    assert_eq!(76561198282694357, sid.0);
+    assert_eq!(322428629, sid.get_account_id());
+    assert_eq!("STEAM_1:1:161214314".to_owned(), sid.to_id2_string());
+    assert_eq!("[U:1:322428629]".to_owned(), sid.to_id3_string());
+    assert_eq!(Universe::Public, sid.get_universe());
+
+    sid.set_account_universe(Universe::Internal as u64).unwrap();
+    assert_eq!(Universe::Internal, sid.get_universe());
 }

--- a/tests/steam_id.rs
+++ b/tests/steam_id.rs
@@ -49,3 +49,9 @@ async fn new_smart() {
     sid.set_account_universe(Universe::Internal as u64).unwrap();
     assert_eq!(Universe::Internal, sid.get_universe());
 }
+
+#[tokio::test]
+async fn from_account_id() {
+    let sid = SteamId::from_account_id(322428629);
+    assert_eq!(Ok(76561198282694357), sid.map(|s| s.0))
+}


### PR DESCRIPTION
This PR adds a new function that allows users to create `SteamId` from u64 string, Steam 2 ID and Steam 3 ID (#15) and another function to create from account id. It also adds some helper function like setting some ID bits manually and displaying ID as 3rd version.
Most of the code is rust implementation of [xPaw's SteamId library](https://github.com/xPaw/SteamID.php).

If you think regex/pomsky is too much I can try and rewrite using nom, but also I'm thinking about adding support for creating `SteamId` from url and regex might be used there too, it wouldn't be impossible without but it's simpler